### PR TITLE
feat: try to skip values for missing attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ end
   * [Enums](./docs/enums.md)
   * [Nested models](./docs/nested_models.md)
   * [Unknown attributes](./docs/unknown_attributes.md)
+  * [Empty attributes](./docs/empty_attributes.md)
 3. [Array of stored models](./docs/array_of_stored_models.md)
 4. [One of](./docs/one_of.md)
 4. [Alternatives](./docs/alternatives.md)

--- a/docs/empty_attributes.md
+++ b/docs/empty_attributes.md
@@ -1,0 +1,29 @@
+# Empty attributes
+
+In some cases, you might want to skip attributes if values were not provided
+For example, here if value was not provided then supplier will be saved as `null` for Configuration instance:
+
+```ruby
+class Supplier
+  include StoreModel::Model
+
+  attribute :title, :string
+end
+
+class Configuration
+  include StoreModel::Model
+
+  attribute :supplier, Supplier.to_type
+end
+```
+
+## Serialization of empty attributes
+
+By default `StoreModel` will serialize empty attributes when you call `as_json` on an instance.
+You can change that behavior globally by turning off serialization for empty attributes.
+
+```ruby
+StoreModel.config.serialize_empty_attributes = false
+```
+
+This option is propagated to array items and nested structures as well.

--- a/lib/store_model/configuration.rb
+++ b/lib/store_model/configuration.rb
@@ -15,6 +15,10 @@ module StoreModel
     # @return [Boolean]
     attr_accessor :serialize_unknown_attributes
 
+    # Controls if the result of `as_json` will contain the nulls attributes of the model
+    # @return [Boolean]
+    attr_accessor :serialize_empty_attributes
+
     # Controls if the result of `as_json` will serialize enum fields using `as_json`
     # @return [Boolean]
     attr_accessor :serialize_enums_using_as_json
@@ -28,6 +32,7 @@ module StoreModel
       @serialize_unknown_attributes = true
       @enable_parent_assignment = true
       @serialize_enums_using_as_json = true
+      @serialize_empty_attributes = true
     end
   end
 end

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -45,7 +45,7 @@ module StoreModel
     # @param options [Hash]
     #
     # @return [Hash]
-    def as_json(options = {}) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    def as_json(options = {}) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
       serialize_unknown_attributes = if options.key?(:serialize_unknown_attributes)
                                        options[:serialize_unknown_attributes]
                                      else
@@ -61,7 +61,8 @@ module StoreModel
       result = @attributes.keys.each_with_object({}) do |key, values|
         attr = @attributes.fetch(key)
         assign_serialization_options(attr, serialize_unknown_attributes, serialize_enums_using_as_json)
-        values[key] = serialized_attribute(attr)
+        serialized = serialized_attribute(attr)
+        values[key] = serialized if StoreModel.config.serialize_empty_attributes || !serialized.nil?
       end.with_indifferent_access
 
       result.merge!(unknown_attributes) if serialize_unknown_attributes

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -35,7 +35,7 @@ module StoreModel
     end
 
     attr_accessor :parent
-    attr_writer :serialize_unknown_attributes, :serialize_enums_using_as_json
+    attr_writer :serialize_unknown_attributes, :serialize_enums_using_as_json, :serialize_empty_attributes
 
     delegate :each_value, to: :attributes
 
@@ -45,7 +45,7 @@ module StoreModel
     # @param options [Hash]
     #
     # @return [Hash]
-    def as_json(options = {}) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
+    def as_json(options = {}) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
       serialize_unknown_attributes = if options.key?(:serialize_unknown_attributes)
                                        options[:serialize_unknown_attributes]
                                      else
@@ -58,11 +58,20 @@ module StoreModel
                                         StoreModel.config.serialize_enums_using_as_json
                                       end
 
+      serialize_empty_attributes = if options.key?(:serialize_empty_attributes)
+                                     options[:serialize_empty_attributes]
+                                   else
+                                     StoreModel.config.serialize_empty_attributes
+                                   end
+
+      # If the model is nested, we need to ensure that the serialization
+
       result = @attributes.keys.each_with_object({}) do |key, values|
         attr = @attributes.fetch(key)
-        assign_serialization_options(attr, serialize_unknown_attributes, serialize_enums_using_as_json)
+        assign_serialization_options(attr, serialize_unknown_attributes, serialize_enums_using_as_json,
+                                     serialize_empty_attributes)
         serialized = serialized_attribute(attr)
-        values[key] = serialized if StoreModel.config.serialize_empty_attributes || !serialized.nil?
+        values[key] = serialized if serialize_empty_attributes || !serialized.nil?
       end.with_indifferent_access
 
       result.merge!(unknown_attributes) if serialize_unknown_attributes
@@ -227,6 +236,23 @@ module StoreModel
       end
     end
 
+    # Returns the value of the `@serialize_empty_attributes` instance
+    # variable. The default value is the value of the globally configured
+    # `serialize_empty_attributes` option.
+    #
+    # This method is used to determine whether empty values should be serialized
+    # when the `as_json` method is called in nested StoreModel::Model
+    # objects.
+    #
+    # @return [Boolean]
+    def serialize_empty_attributes?
+      if @serialize_empty_attributes.nil?
+        StoreModel.config.serialize_empty_attributes || true
+      else
+        @serialize_empty_attributes
+      end
+    end
+
     private
 
     def attribute?(attribute)
@@ -264,16 +290,18 @@ module StoreModel
 
       array.as_json(
         serialize_unknown_attributes: array.first.serialize_unknown_attributes?,
-        serialize_enums_using_as_json: array.first.serialize_enums_using_as_json?
+        serialize_enums_using_as_json: array.first.serialize_enums_using_as_json?,
+        serialize_empty_attributes: array.first.serialize_empty_attributes?
       )
     end
 
-    def assign_serialization_options(attr, serialize_unknown_attributes, serialize_enums_using_as_json)
+    def assign_serialization_options(attr, serialize_unknown_attributes, serialize_enums_using_as_json, serialize_empty_attributes) # rubocop:disable Layout/LineLength
       return unless Array(attr.value).all? { |value| value.is_a?(StoreModel::Model) }
 
       Array(attr.value).each do |value|
         value.serialize_unknown_attributes = serialize_unknown_attributes
         value.serialize_enums_using_as_json = serialize_enums_using_as_json
+        value.serialize_empty_attributes = serialize_empty_attributes
       end
     end
   end

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -204,6 +204,14 @@ RSpec.describe StoreModel::Model do
         include_examples "with unknown attributes"
       end
     end
+
+    context "when serialize_empty_attributes is off" do
+      before do
+        StoreModel.config.serialize_empty_attributes = false
+      end
+
+      it("returns correct JSON") { is_expected.to eq(attributes.except(:model, :encrypted_serial).as_json) }
+    end
   end
 
   describe "#blank?" do

--- a/spec/store_model/types/many_spec.rb
+++ b/spec/store_model/types/many_spec.rb
@@ -217,6 +217,20 @@ RSpec.describe StoreModel::Types::Many do
         end
       end
 
+      context "when empty serialize_empty_attributes is off" do
+        before do
+          StoreModel.config.serialize_empty_attributes = false
+        end
+
+        let(:expected_attributes_array) do
+          attributes_array.map { |attrs| attrs.except(:model, :encrypted_serial) }
+        end
+
+        it "does not serialize empty attributes" do
+          expect(subject).to eq(expected_attributes_array.to_json)
+        end
+      end
+
       context "with enums" do
         context "when serialize_enums_using_as_json attribute of instances is set to true" do
           it "serializes enums by overriding the globally configured behavior" do

--- a/spec/store_model/types/one_spec.rb
+++ b/spec/store_model/types/one_spec.rb
@@ -227,6 +227,16 @@ RSpec.describe StoreModel::Types::One do
         end
       end
 
+      context "when empty serialize_empty_attributes is off" do
+        before do
+          StoreModel.config.serialize_empty_attributes = false
+        end
+
+        it "does not serialize empty attributes" do
+          expect(subject).to eq(attributes.except(:model, :encrypted_serial).to_json)
+        end
+      end
+
       context "with enums" do
         context "when serialize_enums_using_as_json attribute of instance is set to true" do
           it "serializes enums by overriding the globally configured behavior" do


### PR DESCRIPTION
This PR introduces new config option: `serialize_empty_attributes`.
It is on by default, but when turned off, empty values should not be serialized.